### PR TITLE
【更新】针对 gicv 无法多次访问 ICC_IAR1_EL1 寄存器获取 irqno 进行修复

### DIFF
--- a/inc/rti_config.h
+++ b/inc/rti_config.h
@@ -36,6 +36,9 @@
     #else
         #define RTI_GET_ISR_ID()   ((*(rt_uint32_t *)(0xE000ED04)) & 0x3F) // Get the currently active interrupt Id. (i.e. read Cortex-M ICSR[5:0] = active vector)
     #endif
+#elif defined(ARCH_ARM_GIC)
+    #undef RTI_GET_ISR_ID()
+    void rti_interrupt_gic_enter(int irqno);                               // Call in GIC interrupt handler function
 #else
     #error "This kernel is not currently supported, You can implement this function yourself"
     #define RTI_GET_ISR_ID()                                               // Get the currently active interrupt Id from the user-provided function.

--- a/src/rti.c
+++ b/src/rti.c
@@ -188,6 +188,15 @@ static void rti_interrupt_enter(void)
     rti_isr_enter();
 }
 
+#ifdef ARCH_ARM_GIC
+void rti_interrupt_gic_enter(int irqno)
+{
+    if (!rti_status.enable || rti_status.disable_nest[RTI_INTERRUPT_NUM])
+        return ;
+    rti_send_packet_value(RTI_ID_ISR_ENTER, irqno);
+}
+#endif
+
 static void rti_interrupt_leave(void)
 {
     rt_thread_t current;
@@ -787,7 +796,9 @@ static int rti_init(void)
     rt_timer_enter_sethook(rti_timer_enter);
     rt_timer_exit_sethook(rti_timer_exit);
 
+#ifndef ARCH_ARM_GIC
     rt_interrupt_enter_sethook(rti_interrupt_enter);
+#endif
     rt_interrupt_leave_sethook(rti_interrupt_leave);
 
     return 0;


### PR DESCRIPTION
- gic 访问 ICC_IAR1_EL1  会将中断状态改变为 active
- 本次修改后，需要在系统中 gic 处理函数中，调用 rti_interrupt_gic_enter 函数，并传入 irqno